### PR TITLE
Statement separator experimental

### DIFF
--- a/CREInterpreter/Statements/DeclarationStatementSeparator.cs
+++ b/CREInterpreter/Statements/DeclarationStatementSeparator.cs
@@ -1,0 +1,48 @@
+﻿using CREInterpreter.Tokens;
+using System;
+
+namespace CREInterpreter.Statements;
+
+internal static class DeclarationStatementSeparator
+{
+    public static IStatement? GetDeclarationStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index)
+    {
+        ReadOnlySpan<IToken> tokenSpan = chunkTokens.Span[index..];
+        return tokenSpan switch
+        {
+            [TypeNameToken typeNameToken, VariableNameToken variableNameToken, SemicolonSymbolToken, ..] =>
+                new DeclarationStatement(chunkText, chunkTokens[index..(index += 3)], typeNameToken._VarType, variableNameToken.Text),
+
+            [TypeNameToken typeNameToken, OpenSquareBraceSymbolToken, CloseSquareBraceSymbolToken, VariableNameToken variableNameToken,
+                SemicolonSymbolToken, ..] =>
+                new DeclarationStatement(chunkText, chunkTokens[index..(index += 5)], typeNameToken._VarType.Array!, variableNameToken.Text),
+
+            [TypeNameToken typeNameToken, VariableNameToken variableNameToken, EqualsSymbolToken, ..] =>
+                GetDeclarationInitialisationStatement(chunkText, chunkTokens, ref index, tokenSpan[3..], index + 3,
+                    typeNameToken._VarType, variableNameToken.Text),
+
+            [TypeNameToken typeNameToken, OpenSquareBraceSymbolToken, CloseSquareBraceSymbolToken, VariableNameToken variableNameToken,
+                EqualsSymbolToken, ..] =>
+                GetDeclarationInitialisationStatement(chunkText, chunkTokens, ref index, tokenSpan[5..], index + 5,
+                    typeNameToken._VarType.Array!, variableNameToken.Text),
+
+            _ => null
+        };
+    }
+
+    private static IStatement? GetDeclarationInitialisationStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index,
+        ReadOnlySpan<IToken> expressionTokenSpan, int expressionIndex, VarType varType, ReadOnlyMemory<char> variableName)
+    {
+        int startIndex = index;
+        int offset = 0;
+        StatementSeparator.SkipToFirstTopLevelSpecificToken<SemicolonSymbolToken>(expressionTokenSpan, ref offset);
+        if (offset == -1)
+        {
+            index = chunkTokens.Length;
+            return new InvalidStatement(chunkText, chunkTokens[startIndex..], new("Declaration-initialisation statement never followed by a semicolon"));
+        }
+        index += offset + 1;
+        return new DeclarationInitialisationStatement(chunkText, chunkTokens[startIndex..index], varType, variableName,
+            chunkTokens[expressionIndex..(index - 1)]);
+    }
+}

--- a/CREInterpreter/Statements/IInitialiserStatement.cs
+++ b/CREInterpreter/Statements/IInitialiserStatement.cs
@@ -1,3 +1,3 @@
 ﻿namespace CREInterpreter.Statements;
 
-public interface IInitialiserStatement : IStatement { }
+public interface IInitialiserStatement : IStatement;

--- a/CREInterpreter/Statements/IIteratorStatement.cs
+++ b/CREInterpreter/Statements/IIteratorStatement.cs
@@ -1,3 +1,3 @@
 ﻿namespace CREInterpreter.Statements;
 
-public interface IIteratorStatement : IStatement { }
+public interface IIteratorStatement : IStatement;

--- a/CREInterpreter/Statements/StatementExecution.cs
+++ b/CREInterpreter/Statements/StatementExecution.cs
@@ -1,7 +1,3 @@
 ﻿namespace CREInterpreter.Statements;
 
-public readonly struct StatementExecution(IStatement statement, InterpreterException? exception)
-{
-    public IStatement Statement => statement;
-    public InterpreterException? Exception => exception;
-}
+public readonly record struct StatementExecution(IStatement Statement, InterpreterException? Exception);

--- a/CREInterpreter/Statements/StatementSeparator.cs
+++ b/CREInterpreter/Statements/StatementSeparator.cs
@@ -13,6 +13,7 @@ public static class StatementSeparator
             yield return
                 GetEmptyStatement(text, tokens, ref index) ??
                 GetDeclarationStatement(text, tokens, ref index) ??
+                GetWriteStatement(text, tokens, ref index) ??
                 GetInvalidStatement(text, tokens, ref index);
     }
 
@@ -27,26 +28,8 @@ public static class StatementSeparator
     private static IStatement? GetDeclarationStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index) =>
         DeclarationStatementSeparator.GetDeclarationStatement(chunkText, chunkTokens, ref index);
 
-    private static IStatement? GetWriteVariableStatement(ReadOnlyMemory<char> text, ReadOnlyMemory<IToken> tokens, ref int index)
-    {
-        int startIndex = index;
-        ReadOnlySpan<IToken> tokenSpan = tokens.Span;
-        if (tokens.Length < index + 4)
-            return null;
-        if (tokenSpan[index] is not VariableNameToken variableNameToken)
-            return null;
-        if (tokenSpan[index + 1] is not EqualsSymbolToken)
-            return null;
-        //if (!SkipToFirstTopLevelSpecificToken<SemicolonSymbolToken>(tokenSpan, ref index))
-        //    return new InvalidStatement(text, tokens[startIndex..], new($"Write-variable statement not followed up by a semicolon"));
-        return new WriteVariableStatement
-        (
-            text,
-            tokens[startIndex..index],
-            variableNameToken.Text,
-            tokens[(startIndex + 2)..(index - 1)]
-        );
-    }
+    private static IStatement? GetWriteStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index) =>
+        WriteStatementSeparator.GetWriteStatement(chunkText, chunkTokens, ref index);
 
     private static InvalidStatement GetInvalidStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index)
     {

--- a/CREInterpreter/Statements/WriteStatementSeparator.cs
+++ b/CREInterpreter/Statements/WriteStatementSeparator.cs
@@ -1,0 +1,111 @@
+﻿using CREInterpreter.Tokens;
+using System;
+
+namespace CREInterpreter.Statements;
+
+internal static class WriteStatementSeparator
+{
+    public static IStatement? GetWriteStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index)
+    {
+        ReadOnlySpan<IToken> tokenSpan = chunkTokens.Span[index..];
+        return tokenSpan switch
+        {
+            [VariableNameToken variableNameToken, EqualsSymbolToken, ..] =>
+                GetWriteStatement(chunkText, chunkTokens, ref index, tokenSpan[2..], index + 2, variableNameToken.Text, new WriteVariableData()),
+
+            [VariableNameToken variableNameToken, OpenSquareBraceSymbolToken, ..] =>
+                GetWriteElementStatement(chunkText, chunkTokens, ref index, tokenSpan[2..], index + 2, variableNameToken.Text),
+
+            _ => null
+        };
+    }
+
+    private interface IWriteData;
+
+    private readonly record struct WriteVariableData() : IWriteData;
+
+    private readonly record struct WriteElementData((int, int) ElementExpressionBounds) : IWriteData;
+
+    private readonly record struct WriteElementElementData((int, int) Element1ExpressionBounds, (int, int) Element2ExpressionBounds) : IWriteData;
+
+    private static IStatement? GetWriteStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index,
+        ReadOnlySpan<IToken> expressionTokenSpan, int expressionIndex, ReadOnlyMemory<char> variableName, IWriteData writeData)
+    {
+        int startIndex = index;
+        int offset = 0;
+        StatementSeparator.SkipToFirstTopLevelSpecificToken<SemicolonSymbolToken>(expressionTokenSpan, ref offset);
+        if (offset == -1)
+        {
+            index = chunkTokens.Length;
+            return new InvalidStatement(chunkText, chunkTokens[startIndex..], new("Write statement never followed by a semicolon"));
+        }
+        index = expressionIndex + offset + 1;
+        return writeData switch
+        {
+            WriteVariableData data =>
+                new WriteVariableStatement(chunkText, chunkTokens[startIndex..index], variableName, chunkTokens[expressionIndex..(index - 1)]),
+
+            WriteElementData data =>
+                new WriteElementStatement(chunkText, chunkTokens[startIndex..index], variableName,
+                    chunkTokens[data.ElementExpressionBounds.Item1..data.ElementExpressionBounds.Item2], chunkTokens[expressionIndex..(index - 1)]),
+
+            WriteElementElementData data =>
+                new WriteElementElementStatement(chunkText, chunkTokens[startIndex..index], variableName,
+                    chunkTokens[data.Element1ExpressionBounds.Item1..data.Element1ExpressionBounds.Item2],
+                    chunkTokens[data.Element2ExpressionBounds.Item1..data.Element2ExpressionBounds.Item2],
+                    chunkTokens[expressionIndex..(index - 1)]),
+
+            _ => throw new InvalidOperationException("WriteStatementSeparator: unexpected IWriteData type")
+        };
+    }
+
+    private static IStatement? GetWriteElementStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index,
+        ReadOnlySpan<IToken> elementExpressionSpan, int elementExpressionIndex, ReadOnlyMemory<char> variableName)
+    {
+        int startIndex = index;
+        int offset = 0;
+        StatementSeparator.SkipToFirstTopLevelSpecificToken<CloseSquareBraceSymbolToken>(elementExpressionSpan, ref offset);
+        if (offset == -1)
+        {
+            index = chunkTokens.Length;
+            return new InvalidStatement(chunkText, chunkTokens[startIndex..], new("Square brace never closed"));
+        }
+        (int, int) elementExpressionBounds = (elementExpressionIndex, elementExpressionIndex + offset);
+        ReadOnlySpan<IToken> remainingSpan = elementExpressionSpan[(offset + 1)..];
+        return remainingSpan switch
+        {
+            [EqualsSymbolToken, ..] =>
+                GetWriteStatement(chunkText, chunkTokens, ref index, remainingSpan[1..], elementExpressionIndex + offset + 2, variableName,
+                    new WriteElementData(elementExpressionBounds)),
+
+            [OpenSquareBraceSymbolToken, ..] =>
+                GetWriteElementElementStatement(chunkText, chunkTokens, ref index, remainingSpan[1..], elementExpressionIndex + offset + 2, variableName,
+                    elementExpressionBounds),
+
+            _ => null
+        };
+    }
+
+    private static IStatement? GetWriteElementElementStatement(ReadOnlyMemory<char> chunkText, ReadOnlyMemory<IToken> chunkTokens, ref int index,
+        ReadOnlySpan<IToken> element2ExpressionSpan, int element2ExpressionIndex, ReadOnlyMemory<char> variableName, (int, int) element1ExpressionBounds)
+    {
+        int startIndex = index;
+        int offset = 0;
+        StatementSeparator.SkipToFirstTopLevelSpecificToken<CloseSquareBraceSymbolToken>(element2ExpressionSpan, ref offset);
+        if (offset == -1)
+        {
+            index = chunkTokens.Length;
+            return new InvalidStatement(chunkText, chunkTokens[startIndex..], new("Square brace never closed"));
+        }
+        (int, int) element2ExpressionBounds = (element2ExpressionIndex, element2ExpressionIndex + offset);
+        ReadOnlySpan<IToken> remainingSpan = element2ExpressionSpan[(offset + 1)..];
+        return remainingSpan switch
+        {
+            [EqualsSymbolToken, ..] =>
+                GetWriteStatement(chunkText, chunkTokens, ref index, remainingSpan[1..], element2ExpressionIndex + offset + 2, variableName,
+                    new WriteElementElementData(element1ExpressionBounds, element2ExpressionBounds)),
+
+            _ => null
+        };
+    }
+}

--- a/CREInterpreter/Tokens/ICloseToken.cs
+++ b/CREInterpreter/Tokens/ICloseToken.cs
@@ -1,3 +1,3 @@
 ﻿namespace CREInterpreter.Tokens;
 
-public interface ICloseToken : IToken { }
+public interface ICloseToken : IToken;

--- a/CREInterpreter/Tokens/IOpenToken.cs
+++ b/CREInterpreter/Tokens/IOpenToken.cs
@@ -1,3 +1,3 @@
 ﻿namespace CREInterpreter.Tokens;
 
-public interface IOpenToken : IToken { }
+public interface IOpenToken : IToken;


### PR DESCRIPTION
Moved particularly complicated separations to their own class so that we can pursue a functional approach there - without cluttering the main StatementSeparator class.